### PR TITLE
refactor: editor wrapper height calculation and borders

### DIFF
--- a/web/components/editor/editor.css
+++ b/web/components/editor/editor.css
@@ -2,6 +2,16 @@
   outline: none !important;
 }
 
+.cm-editor {
+  border-bottom-right-radius: 4px;
+}
+
+.cm-editor,
+.cm-gutter,
+.cm-gutters {
+  border-bottom-left-radius: 4px;
+}
+
 .cm-tooltip-hover,
 .cm-tooltip,
 .ͼ1 .cm-tooltip {

--- a/web/components/editor/editor.tsx
+++ b/web/components/editor/editor.tsx
@@ -241,37 +241,25 @@ export default function Editor(props: EditorProps) {
   const codeMirrorHeight = useMemo(() => {
     if (props.type === "level") {
       if (windowWidth >= BP_3XL) {
-        return "579px";
+        return 580;
       }
       if (windowWidth >= BP_2XL) {
-        return "454px";
+        return 454;
       }
       if (windowWidth >= BP_XL) {
-        return "370px";
+        return 370;
       }
-      return "273px";
-    }
-    return "auto";
-  }, [props.type, windowWidth]);
-
-  const editorWrapperHeight = useMemo(() => {
-    if (props.type === "level") {
-      if (windowWidth >= BP_3XL) {
-        return "582px";
-      }
-      if (windowWidth >= BP_2XL) {
-        return "457px";
-      }
-      if (windowWidth >= BP_XL) {
-        return "373px";
-      }
-      return "276px";
+      return 276;
     }
     return undefined;
   }, [props.type, windowWidth]);
 
+  const editorBorderWidth = 2;
+
+  const editorWrapperHeight = codeMirrorHeight ? `${codeMirrorHeight + editorBorderWidth}px` : undefined;
+
   const { setContainer, view } = useCodeMirror({
-    height: codeMirrorHeight,
+    height: codeMirrorHeight ? `${codeMirrorHeight}px` : "auto",
     editable: state === "editing",
     readOnly: state !== "editing",
     indentWithTab: false,


### PR DESCRIPTION
| before | after |
|--------|------|
| <img width="933" alt="Screen Shot 2023-12-06 at 8 30 54 PM" src="https://github.com/albrow/elara/assets/1877652/ecb7b835-95c2-4654-9c28-8c16c97b688b"> | <img width="1010" alt="Screen Shot 2023-12-06 at 8 31 49 PM" src="https://github.com/albrow/elara/assets/1877652/f2353c45-fbd3-4edb-829f-70b0110551c8"> |
| <img width="351" alt="Screen Shot 2023-12-06 at 8 33 58 PM" src="https://github.com/albrow/elara/assets/1877652/656601cc-66c6-4fbd-8342-1bfd611dc845"> | <img width="305" alt="Screen Shot 2023-12-06 at 8 33 48 PM" src="https://github.com/albrow/elara/assets/1877652/cb00b234-4bd4-4f79-b96c-8c79ffec204b"> |
| <img width="242" alt="Screen Shot 2023-12-06 at 8 34 01 PM" src="https://github.com/albrow/elara/assets/1877652/1865e41b-e874-419e-aa28-54a3f1518382"> | <img width="309" alt="Screen Shot 2023-12-06 at 8 34 14 PM" src="https://github.com/albrow/elara/assets/1877652/bb145f46-8f12-4429-ae70-291b4a17c98f"> |





